### PR TITLE
Use verbose=2 to avoid Jupyter hanging browser

### DIFF
--- a/mnist-mlp/mnist_mlp.ipynb
+++ b/mnist-mlp/mnist_mlp.ipynb
@@ -409,7 +409,7 @@
     "\n",
     "# train the model\n",
     "checkpointer = ModelCheckpoint(filepath='mnist.model.best.hdf5', \n",
-    "                               verbose=1, save_best_only=True)\n",
+    "                               verbose=2, save_best_only=True)\n",
     "hist = model.fit(X_train, y_train, batch_size=128, epochs=10,\n",
     "          validation_split=0.2, callbacks=[checkpointer],\n",
     "          verbose=1, shuffle=True)"


### PR DESCRIPTION
I've encountered the browser hanging during training a Keras model when passing `verbose=1` to the `[model.fit()](https://keras.io/models/model/#fit)` method.   The issue is tracked in fchollet/keras#4880 and a simple solution is to use `verbose=2` which still provides per epoch stats.