### PR TITLE
Correct typo in 3 ipynbs

### DIFF
--- a/cifar10-augmentation/cifar10_augmentation.ipynb
+++ b/cifar10-augmentation/cifar10_augmentation.ipynb
@@ -40,7 +40,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### 2. Visualize the First 24 Training Images"
+    "### 2. Visualize the First 36 Training Images"
    ]
   },
   {

--- a/cifar10-classification/cifar10_cnn.ipynb
+++ b/cifar10-classification/cifar10_cnn.ipynb
@@ -50,7 +50,7 @@
     "editable": true
    },
    "source": [
-    "### 2. Visualize the First 24 Training Images"
+    "### 2. Visualize the First 36 Training Images"
    ]
   },
   {

--- a/cifar10-classification/cifar10_mlp.ipynb
+++ b/cifar10-classification/cifar10_mlp.ipynb
@@ -50,7 +50,7 @@
     "editable": true
    },
    "source": [
-    "### 2. Visualize the First 24 Training Images"
+    "### 2. Visualize the First 36 Training Images"
    ]
   },
   {


### PR DESCRIPTION
Header says code displays 24 images. Code actually displays 36. Cut-n-paste error in 3 notebooks.